### PR TITLE
fix(#142):  update normalizeSync input type to string only

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,14 +85,14 @@ await normalize('söme stüff with áccènts'); // 'some stuff with accents'
 
 ## API Reference
 
-### normalize([input])
+### `normalize([input])`
 
-- `input` <?[string][string-mdn-url]> Optional input string that contains accents/ diacritics.
+- `input` <[string][string-mdn-url]> input string that contains accents/diacritics.
 - returns: <[Promise][promise-mdn-url]<[string][string-mdn-url]>> Promise which resolves with normalized input string.
 
 This method normalizes any accents/ diacritics found in a given input string and output a normalized string as a result.
 
-### normalizeSync([input])
+### `normalizeSync([input])`
 
 This methods works the same as `normalize([input])` except that this is the synchronous version.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@reallyland/tools": "^0.3.1",
         "@vitest/coverage-c8": "^0.25.7",
-        "typescript": "^5.1.6",
+        "typescript": "^5.2.2",
         "vitest": "^0.25.7"
       },
       "engines": {
@@ -1657,10 +1657,13 @@
       "optional": true
     },
     "node_modules/@types/node": {
-      "version": "20.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.5.tgz",
-      "integrity": "sha512-2qGq5LAOTh9izcc0+F+dToFigBWiK1phKPt7rNhOqJSr35y8rlIBjDwGtFSgAI6MGIhjwOVNSQZVdJsZJ2uR1w==",
-      "dev": true
+      "version": "20.11.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
+      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.2",
@@ -5574,9 +5577,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -6419,9 +6422,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
+      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -6446,6 +6449,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -8033,10 +8042,13 @@
       "optional": true
     },
     "@types/node": {
-      "version": "20.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.5.tgz",
-      "integrity": "sha512-2qGq5LAOTh9izcc0+F+dToFigBWiK1phKPt7rNhOqJSr35y8rlIBjDwGtFSgAI6MGIhjwOVNSQZVdJsZJ2uR1w==",
-      "dev": true
+      "version": "20.11.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
+      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.2",
@@ -10941,9 +10953,9 @@
       }
     },
     "semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -11611,9 +11623,9 @@
       }
     },
     "typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
+      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
       "dev": true
     },
     "unbox-primitive": {
@@ -11628,6 +11640,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "universalify": {
       "version": "0.1.2",

--- a/src/normalize-sync.ts
+++ b/src/normalize-sync.ts
@@ -1,6 +1,6 @@
 import { diacritics } from './diacritics.js';
 
-export function normalizeSync(input?: string | null): string {
+export function normalizeSync(input: string): string {
   if ('string' !== typeof(input)) {
     throw new TypeError(`Expected 'input' to be of type string, but received '${input}'`);
   }
@@ -28,6 +28,5 @@ export function normalizeSync(input?: string | null): string {
     );
 
     return normalized == null ? s : normalized.letter;
-    // return null == normalized ? s : normalized.letter;
   });
 }

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -1,5 +1,5 @@
 import { normalizeSync } from './normalize-sync.js';
 
-export async function normalize(input?: string | null): Promise<string> {
+export async function normalize(input: string): Promise<string> {
   return normalizeSync(input);
 }

--- a/src/tests/error.test.ts
+++ b/src/tests/error.test.ts
@@ -8,6 +8,7 @@ describe(normalize.name, () => {
     undefined,
   ])('throws error when calling normalize(%s)', async (testInput) => {
     try {
+      // @ts-expect-error - Intentionally passing invalid input
       await normalize(testInput);
     } catch (error) {
       expect(error).toEqual(


### PR DESCRIPTION
### Description

Fix #142 

### Changes

- Make `input` parameter for `normalizeSync`, `normalize` required, `string` only
- Update README
- Update test

### Testings

```

> normalize-diacritics@4.0.3 test
> vitest --coverage


 DEV  v0.25.7 /Users/opsparkowl/Documents/side_projects/normalize-diacritics
      Coverage enabled with c8

 ✓ src/tests/error.test.ts (2)
 ✓ src/tests/normalize-sync.test.ts (14)
 ✓ src/tests/normalize.test.ts (14)

 Test Files  3 passed (3)
      Tests  30 passed (30)
   Start at  15:51:55
   Duration  955ms (transform 406ms, setup 0ms, collect 175ms, tests 38ms)

 % Coverage report from c8
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |
 diacritics.ts     |     100 |      100 |     100 |     100 |
 index.ts          |     100 |      100 |     100 |     100 |
 normalize-sync.ts |     100 |      100 |     100 |     100 |
 normalize.ts      |     100 |      100 |     100 |     100 |
 types.ts          |     100 |      100 |     100 |     100 |
-------------------|---------|----------|---------|---------|-------------------

```

